### PR TITLE
Add ownerOfWithin

### DIFF
--- a/assets/eip-7108/contracts/ClusteredNFT.sol
+++ b/assets/eip-7108/contracts/ClusteredNFT.sol
@@ -21,6 +21,7 @@ contract ClusteredNFT is IERC7108, ERC721 {
   error SizeTooLarge();
   error ClusterFull();
   error ClusterNotFound();
+  error TokenDoesNotExist();
 
   struct Cluster {
     address owner;
@@ -132,6 +133,12 @@ contract ClusteredNFT is IERC7108, ERC721 {
 
   function rangeOf(uint256 clusterId) public view override returns (uint256, uint256) {
     return (clusters[clusterId].firstTokenId, clusters[clusterId].firstTokenId + clusters[clusterId].size - 1);
+  }
+
+  function ownerOfWithin(uint256 normalizedTokenId_, uint256 clusterId) external view returns (address) {
+    if (clusters[clusterId].owner == address(0)) revert ClusterNotFound();
+    if (normalizedTokenId_ > clusters[clusterId].size) revert TokenDoesNotExist();
+    return ownerOf(clusters[clusterId].firstTokenId + normalizedTokenId_ - 1);
   }
 
   function clusterOwner(uint256 clusterId) public view override returns (address) {

--- a/assets/eip-7108/contracts/IERC7108.sol
+++ b/assets/eip-7108/contracts/IERC7108.sol
@@ -50,6 +50,16 @@ interface IERC7108 {
   function rangeOf(uint256 clusterId) external view returns (uint256, uint256);
 
   /**
+   * @notice Gets the owner of a tokenId within a cluster
+      This function can be gas consuming and it is supposed to be called from
+      dApps rather than internally or from other smart contracts
+   * @param normalizedTokenId_ The normalized ID of the token
+   * @param clusterId ID of the cluster
+   * @return the address of the owner of the token, if it exists
+   */
+  function ownerOfWithin(uint256 normalizedTokenId_, uint256 clusterId) external view returns (address);
+
+  /**
    * @notice Gets the owner of a cluster
    * @param clusterId ID of the cluster
    * @return address Owner of the cluster

--- a/assets/eip-7108/test/index.test.js
+++ b/assets/eip-7108/test/index.test.js
@@ -14,7 +14,7 @@ describe.only("ClusteredNFT", function () {
     clusteredNFT = await ClusteredNFT.deploy("ClusteredNFT", "cNFT");
     await clusteredNFT.deployed();
 
-    expect(await clusteredNFT.getInterfaceId()).equal("0x4d676ad4");
+    expect(await clusteredNFT.getInterfaceId()).equal("0x4e24b874");
 
     ClusteredNFTEnumerable = await ethers.getContractFactory("ClusteredNFTEnumerable");
     clusteredNFTEnumerable = await ClusteredNFTEnumerable.deploy("ClusteredNFT", "cNFT");
@@ -76,6 +76,8 @@ describe.only("ClusteredNFT", function () {
       expect(await clusteredNFT.normalizedTokenId(2223)).equal(1);
       expect(await clusteredNFT.normalizedTokenId(2224)).equal(2);
       expect(await clusteredNFT.normalizedTokenId(2225)).equal(3);
+
+      expect(await clusteredNFT.ownerOfWithin(1, 0)).equal(bob.address);
 
       expect(await clusteredNFT.tokenURI(2224)).equal("https://bud-token.cc/meta/2");
 


### PR DESCRIPTION
Adds needed function

```
  /**
   * @notice Gets the owner of a tokenId within a cluster
      This function can be gas consuming and it is supposed to be called from
      dApps rather than internally or from other smart contracts
   * @param normalizedTokenId_ The normalized ID of the token
   * @param clusterId ID of the cluster
   * @return the address of the owner of the token, if it exists
   */
  function ownerOfWithin(uint256 normalizedTokenId_, uint256 clusterId) external view returns (address);
```